### PR TITLE
80 rework/image carousel mobile

### DIFF
--- a/frontend/src/components/home/Carousel.tsx
+++ b/frontend/src/components/home/Carousel.tsx
@@ -4,136 +4,138 @@ import "react-multi-carousel/lib/styles.css";
 import useCarousel from "../../hooks/useCarousel.ts";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
-  faArrowAltCircleLeft,
-  faArrowAltCircleRight,
+	faArrowAltCircleLeft,
+	faArrowAltCircleRight,
 } from "@fortawesome/free-solid-svg-icons";
 
 const ButtonGroup: React.FC<{
-  next: () => void;
-  previous: () => void;
+	next: () => void;
+	previous: () => void;
 }> = ({ next, previous }) => {
-  return (
-    <div
-      className="absolute top-[40%] w-full flex justify-between items-center"
-      role="group"
-      aria-label="Carousel Navigation"
-    >
-      {/* Left Arrow */}
-      <button
-        onClick={previous}
-        className="hidden sm:block text-white focus:outline-none -left-16 absolute"
-        aria-label="Previous Slide"
-        type="button"
-      >
-        <FontAwesomeIcon icon={faArrowAltCircleLeft} size="2x" />
-      </button>
+	return (
+		<div
+			className="absolute top-[40%] w-full flex justify-between items-center"
+			role="group"
+			aria-label="Carousel Navigation"
+		>
+			{/* Left Arrow */}
+			<button
+				onClick={previous}
+				className="hidden sm:block text-white focus:outline-none -left-16 absolute"
+				aria-label="Previous Slide"
+				type="button"
+			>
+				<FontAwesomeIcon icon={faArrowAltCircleLeft} size="2x" />
+			</button>
 
-      {/* Right Arrow */}
-      <button
-        onClick={next}
-        className="hidden sm:block text-white focus:outline-none -right-16 absolute"
-        aria-label="Next slide"
-        type="button"
-      >
-        <FontAwesomeIcon icon={faArrowAltCircleRight} size="2x" />
-      </button>
-    </div>
-  );
+			{/* Right Arrow */}
+			<button
+				onClick={next}
+				className="hidden sm:block text-white focus:outline-none -right-16 absolute"
+				aria-label="Next slide"
+				type="button"
+			>
+				<FontAwesomeIcon icon={faArrowAltCircleRight} size="2x" />
+			</button>
+		</div>
+	);
 };
 
+const isMobile = typeof window !== "undefined" && window.innerWidth < 640; // Const checks if window is mobile screen size
+
 const CustomDot: React.FC<{
-  onClick: () => void;
-  active: boolean;
-  index: number;
-  totalSlides: number;
+	onClick: () => void;
+	active: boolean;
+	index: number;
+	totalSlides: number;
 }> = ({ onClick, active, index, totalSlides }) => (
-  <button
-    onClick={onClick}
-    className={`w-3 h-3 rounded-full mx-1 border-2 transition-all focus:outline-none ${
-      active ? "bg-white border-white" : "border-white bg-transparent"
-    }`}
-    aria-label={`Go to slide ${index + 1} of ${totalSlides}`}
-    aria-current={active ? "true" : "false"}
-  ></button>
+	<button
+		onClick={onClick}
+		className={`w-3 h-3 rounded-full mx-1 border-2 transition-all focus:outline-none ${
+			active ? "bg-white border-white" : "border-white bg-transparent"
+		}`}
+		aria-label={`Go to slide ${index + 1} of ${totalSlides}`}
+		aria-current={active ? "true" : "false"}
+	></button>
 );
 
 const MyCarousel: React.FC = () => {
-  const { carousels } = useCarousel();
+	const { carousels } = useCarousel();
 
-  const responsive = {
-    desktop: {
-      breakpoint: { max: 3000, min: 1280 },
-      items: 4,
-    },
-    medium: {
-      breakpoint: { max: 1280, min: 1024 },
-      items: 3,
-    },
-    tablet: {
-      breakpoint: { max: 1024, min: 640 },
-      items: 2,
-    },
-    mobile: {
-      breakpoint: { max: 640, min: 0 },
-      items: 1,
-    },
-  };
-  if (!carousels?.length) return null;
+	const responsive = {
+		desktop: {
+			breakpoint: { max: 3000, min: 1280 },
+			items: 4,
+		},
+		medium: {
+			breakpoint: { max: 1280, min: 1024 },
+			items: 3,
+		},
+		tablet: {
+			breakpoint: { max: 1024, min: 640 },
+			items: 2,
+		},
+		mobile: {
+			breakpoint: { max: 640, min: 0 },
+			items: 1.1,
+		},
+	};
+	if (!carousels?.length) return null;
 
-  return (
-    <>
-      <section
-        className="w-full flex flex-col items-center px-5 py-10 sm:p-10"
-        aria-label="Image Carousel"
-      >
-        <div className="relative pb-16 w-full sm:w-[85%] xl:w-[90%]">
-          <Carousel
-            responsive={responsive}
-            ssr={true}
-            infinite={true}
-            autoPlay={true}
-            autoPlaySpeed={5000}
-            keyBoardControl={true}
-            customTransition="transform 0.5s ease-in-out"
-            transitionDuration={500}
-            containerClass="carousel-container"
-            itemClass="sm:px-4"
-            renderButtonGroupOutside={true}
-            customButtonGroup={
-              <ButtonGroup next={() => {}} previous={() => {}} />
-            }
-            arrows={false}
-            showDots={true}
-            renderDotsOutside={true}
-            customDot={
-              <CustomDot
-                onClick={() => {}}
-                active={false}
-                index={0}
-                totalSlides={carousels.length}
-              />
-            }
-          >
-            {carousels.map((image, index) => (
-              <div
-                key={index}
-                className="w-full h-[300px] flex-shrink-0 overflow-hidden"
-                role="group"
-                aria-roledescription="slide"
-                aria-label={`Slide ${index + 1} of ${carousels.length}`}
-              >
-                <img
-                  src={image.image.asset.url}
-                  alt={image.alt || `Carousel image ${index + 1}`}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-            ))}
-          </Carousel>
-        </div>
-      </section>
-    </>
-  );
+	return (
+		<>
+			<section
+				className="w-full flex flex-col items-center px-5 py-10 sm:p-10"
+				aria-label="Image Carousel"
+			>
+				<div className="relative pb-16 w-full sm:w-[85%] xl:w-[90%]">
+					<Carousel
+						responsive={responsive}
+						ssr={true}
+						infinite={true}
+						autoPlay={!isMobile}
+						autoPlaySpeed={5000}
+						keyBoardControl={true}
+						customTransition="transform 0.5s ease-in-out"
+						transitionDuration={500}
+						containerClass="carousel-container"
+						itemClass="px-2 sm:px-4 flex"
+						renderButtonGroupOutside={true}
+						customButtonGroup={
+							<ButtonGroup next={() => {}} previous={() => {}} />
+						}
+						arrows={false}
+						showDots={true}
+						renderDotsOutside={true}
+						customDot={
+							<CustomDot
+								onClick={() => {}}
+								active={false}
+								index={0}
+								totalSlides={carousels.length}
+							/>
+						}
+					>
+						{carousels.map((image, index) => (
+							<div
+								key={index}
+								className="w-full h-[300px] flex-shrink-0 overflow-hidden"
+								role="group"
+								aria-roledescription="slide"
+								aria-label={`Slide ${index + 1} of ${carousels.length}`}
+							>
+								<img
+									src={image.image.asset.url}
+									alt={image.alt || `Carousel image ${index + 1}`}
+									className="w-[90%] mx-auto h-full object-cover"
+								/>
+							</div>
+						))}
+					</Carousel>
+				</div>
+			</section>
+		</>
+	);
 };
 
 export default MyCarousel;

--- a/frontend/src/components/home/SubImage.tsx
+++ b/frontend/src/components/home/SubImage.tsx
@@ -5,71 +5,71 @@ import useSubImage from "../../hooks/useSubImage.ts";
 import MyCarousel from "./Carousel.tsx";
 
 const SubImage: React.FC = () => {
-  const { subImage } = useSubImage();
-  const { isLoading } = useLoading();
+	const { subImage } = useSubImage();
+	const { isLoading } = useLoading();
 
-  return (
-    <>
-      {!isLoading && subImage && (
-        <section className="bg-[#1a1a2e] py-10 w-screen overflow-x-hidden">
-          <MyCarousel />
+	return (
+		<>
+			{!isLoading && subImage && (
+				<section className="bg-[#1a1a2e] py-10 w-screen">
+					<MyCarousel />
 
-          <section className="w-screen">
-            {/* Container to display images in a row */}
-            <div className="grid grid-cols-1 sm:grid-cols-3 gap-16 sm:gap-8 xl:gap-14 px-5 py-10 sm:p-10">
-              {/* Image 1 */}
+					<section className="w-screen">
+						{/* Container to display images in a row */}
+						<div className="grid grid-cols-1 sm:grid-cols-3 gap-16 sm:gap-8 xl:gap-14 px-5 py-10 sm:p-10">
+							{/* Image 1 */}
 
-              <div>
-                <div className="w-full aspect-square overflow-hidden">
-                  <Link to="/#">
-                    <img
-                      src={subImage.image.asset.url}
-                      alt={subImage.alt}
-                      className="w-full h-full object-cover"
-                    />
-                  </Link>
-                </div>
+							<div>
+								<div className="w-full aspect-square overflow-hidden">
+									<Link to="/blog">
+										<img
+											src={subImage.image.asset.url}
+											alt={subImage.alt}
+											className="w-full h-full object-cover"
+										/>
+									</Link>
+								</div>
 
-                <h4 className="text-white mt-4 font-semibold">
-                  {subImage.header}
-                </h4>
-              </div>
-              {/* Image 2 */}
-              <div>
-                <div className="w-full aspect-square overflow-hidden">
-                  <Link to="/makersspace">
-                    <img
-                      src={subImage.image2.asset.url}
-                      alt={subImage.alt2}
-                      className="w-full h-full object-cover"
-                    />
-                  </Link>
-                </div>
-                <h4 className="text-white mt-4 font-semibold">
-                  {subImage.header2}
-                </h4>
-              </div>
-              {/* Image 3 */}
-              <div>
-                <div className="w-full aspect-square overflow-hidden">
-                  <Link to="/blog">
-                    <img
-                      src={subImage.image3.asset.url}
-                      alt={subImage.alt3}
-                      className="w-full h-full object-cover"
-                    />
-                  </Link>
-                </div>
-                <h4 className="text-white mt-4 font-semibold">
-                  {subImage.header3}
-                </h4>
-              </div>
-            </div>
-          </section>
-        </section>
-      )}
-    </>
-  );
+								<h4 className="text-white mt-4 font-semibold">
+									{subImage.header}
+								</h4>
+							</div>
+							{/* Image 2 */}
+							<div>
+								<div className="w-full aspect-square overflow-hidden">
+									<Link to="/makersspace">
+										<img
+											src={subImage.image2.asset.url}
+											alt={subImage.alt2}
+											className="w-full h-full object-cover"
+										/>
+									</Link>
+								</div>
+								<h4 className="text-white mt-4 font-semibold">
+									{subImage.header2}
+								</h4>
+							</div>
+							{/* Image 3 */}
+							<div>
+								<div className="w-full aspect-square overflow-hidden">
+									<Link to="/blog">
+										<img
+											src={subImage.image3.asset.url}
+											alt={subImage.alt3}
+											className="w-full h-full object-cover"
+										/>
+									</Link>
+								</div>
+								<h4 className="text-white mt-4 font-semibold">
+									{subImage.header3}
+								</h4>
+							</div>
+						</div>
+					</section>
+				</section>
+			)}
+		</>
+	);
 };
 
 export default SubImage;

--- a/frontend/src/components/home/SubImage.tsx
+++ b/frontend/src/components/home/SubImage.tsx
@@ -11,7 +11,7 @@ const SubImage: React.FC = () => {
 	return (
 		<>
 			{!isLoading && subImage && (
-				<section className="bg-[#1a1a2e] py-10 w-screen">
+				<section className="bg-[#1a1a2e] py-10 w-screen mx:overflow-x-hidden">
 					<MyCarousel />
 
 					<section className="w-screen">


### PR DESCRIPTION
## What has been done: 

The image carousel on the main page now looks like this: 

<img width="196" alt="image" src="https://github.com/user-attachments/assets/700ac4c8-9da2-4216-adc6-4c45d748a257" />

Changed so autoplay on carousel is false when on mobile
Changed it so it still makes overflow hidden on bigger screens.


--
Have not been able to test the minor bug of swiping through carousel when on mobile
